### PR TITLE
get controller info with CI2 and CI3 compatible ways

### DIFF
--- a/libraries/Profiler.php
+++ b/libraries/Profiler.php
@@ -421,7 +421,7 @@ class CI_Profiler extends CI_Loader {
 	 */
 	protected function _compile_controller_info()
 	{
-		$output = $this->CI->router->fetch_class()."/".$this->CI->router->fetch_method();
+		$output = $this->CI->router->class."/".$this->CI->router->method;
 
 		return $output;
 	}


### PR DESCRIPTION
* fixed https://github.com/lonnieezell/codeigniter-forensics/issues/33 property
* closed https://github.com/lonnieezell/codeigniter-forensics/issues/33
* also it's still compatible and works with php 5.2 and codeigniter 2.X